### PR TITLE
Typo in shell code 'contiuue' -> 'continue'

### DIFF
--- a/wrfv2_fire/external/io_grib_share/build/library_rules.mk
+++ b/wrfv2_fire/external/io_grib_share/build/library_rules.mk
@@ -47,7 +47,7 @@ all lib archive linked_lib clean depend clean_depend clean_lib:
 		fi ; \
 		if [ ! -d "$$d" ]; then \
 			echo "        Error: subdir $$d is NOT a directory!"; \
-			contiuue ;\
+			continue ;\
 		fi ; \
 		if [ ! -r "$$d/Makefile" ]; then\
 			echo "        Error: subdir $$d does NOT contain a Makefile!"; \


### PR DESCRIPTION
I found a typo in the GRIB library build scripts that was causing the build process described in http://www.openwfm.org/wiki/How_to_run_WRF-Fire to fail out of the box.  This fixed it.

I am working with Dr. Jeff Pierce at Colorado State, where he plans to run this model on our Linux cluster.